### PR TITLE
Checkstyle workout

### DIFF
--- a/android/checkstyle.xml
+++ b/android/checkstyle.xml
@@ -113,7 +113,6 @@
         <module name="HiddenField"/>
         <module name="IllegalInstantiation"/>
         <module name="InnerAssignment"/>
-        <module name="MagicNumber"/>
         <module name="MissingSwitchDefault"/>
         <module name="SimplifyBooleanExpression"/>
         <module name="SimplifyBooleanReturn"/>

--- a/android/checkstyle.xml
+++ b/android/checkstyle.xml
@@ -73,7 +73,7 @@
         <!-- Checks for Size Violations.                    -->
         <!-- See http://checkstyle.sf.net/config_sizes.html -->
         <module name="LineLength">
-            <property name="max" value="100"/>
+            <property name="max" value="120"/>
         </module>
         <module name="MethodLength"/>
 


### PR DESCRIPTION
1. Increase max line length 100 ->120 columns. Now its not very thin and we still can open 2 windows on 1080p monitor without text wrapping.
2. Remove MagicNumberModule cuz it has some problems in unit tests.
   For example 

```
String source = '[1,2,3]';
int[] elems = parser.ParseArray(source);
assertEquals(3, elems.size());
```
